### PR TITLE
change listing post endpoint to accept posts at root and client defin…

### DIFF
--- a/api/v1/endpoints/listings.py
+++ b/api/v1/endpoints/listings.py
@@ -18,7 +18,7 @@ log = logging.getLogger()
 ns = api.namespace('v1/listings', description='Manage FFA Listings in the Datatrust')
 
 
-@ns.route('/', methods=['GET', 'POST'])
+@ns.route('/', methods=['GET'])
 class Listings(Resource):
     @api.expect(endpoint_arguments)
     @api.marshal_with(list_of_listings)
@@ -33,12 +33,12 @@ class Listings(Resource):
         listings = ''
         return listings
 
-@ns.route('/<listing_hash>', methods=['POST'])
+@ns.route('/', methods=['POST'])
 class Listing(Resource):
     @api.expect(listing_arguments)
     @api.response(201, 'Listing successfully added')
     @api.response(500, 'Listing failed due to server side error')
-    def post(self, listing_hash):
+    def post(self):
         """
         Persist a new listing to file storage, db, and protocol
         """
@@ -48,6 +48,12 @@ class Listing(Resource):
         md5_sum = None
         tags = None
         uploaded_md5 = None
+        filenames = []
+        listing_hash = None
+        if not request.form.get('listing_hash'):
+            return 'No listing hash provided', 400
+        else:
+            listing_hash = request.form.get('listing_hash')
         if not request.form.get('file_type'):
             return 'No file type specified', 400
         else:
@@ -58,24 +64,29 @@ class Listing(Resource):
             md5_sum = request.form.get('md5_sum')
         if request.form.get('tags'):
             tags = request.form.get('tags')
-        for item in request.files.items():
+        if request.form.get('filenames'):
+            filenames = request.form.get('filenames').split(',')
+        for idx, item in enumerate(request.files.items()):
             destination = os.path.join('/tmp/uploads/')
-            log.info(f'Saving {item[0]} to {destination}')
+            filename = filenames[idx] if idx < len(filenames) else item[0]
+            log.info(f'Saving {filename} to {destination}')
             if not os.path.exists(destination):
                 os.makedirs(destination)
-            item[1].save(f'{destination}{item[0]}')
-            with open(f'{destination}{item[0]}', 'rb') as data:
+            item[1].save(f'{destination}{filename}')
+            with open(f'{destination}{filename}', 'rb') as data:
                 contents = data.read()
                 uploaded_md5 = hashlib.md5(contents).hexdigest()
             if uploaded_md5 != md5_sum:
                 return 'File upload failed', 500
             local_finish = time.time()
             timings['local_save'] = local_finish - start_time
-            log.info(f'Saving {item[0]} to S3 bucket ffa-dev')
+            log.info(f'Saving {filename} to S3 bucket ffa-dev')
             s3 = boto3.client('s3')
-            with open(f'{destination}{item[0]}', 'rb') as data:
-                s3.upload_fileobj(data, 'ffa-dev', item[0])
+            with open(f'{destination}{filename}', 'rb') as data:
+                # apparently this overwrites existing files.
+                # something to think about?
+                s3.upload_fileobj(data, 'ffa-dev', filename)
             timings['s3_save'] = time.time() - local_finish
-            os.remove(f'{destination}{item[0]}')
+            os.remove(f'{destination}{filename}')
         log.info(timings)
         return 'You uploaded a file'


### PR DESCRIPTION
…ed fliename

There are two changes suggested in this PR (both of them are somewhat necessitated by dropzone):

Dropzone in Typescript has a problem where `options: DropzoneOptions` is set to `static` in the effing type.  I tried to override this behavior via a new `.d.ts` but it wasn't working.  The other js workaround is to drop the default Dropzone upload and write our own with something like Axios or Superagent or whatever - not that hard but editing the flask code is easier/faster.

1. I removed the path param as I can't alter the stupid Dropzone url after the class is instantiated.  The listing hash is now passed as a param and I think this is acceptably RESTful.

2. I added a new param `filenames` that needs to be a comma delimited string.  There is a change inside the loop where the filename is read from the param.  It's up to the client to send an appropriate string of filenames.