### PR TITLE
Bug fixes to datatrust registration

### DIFF
--- a/api/v1/endpoints/listings.py
+++ b/api/v1/endpoints/listings.py
@@ -77,12 +77,12 @@ class Listing(Resource):
                 api.abort(500, (constants.SERVER_ERROR % 'file upload failed'))
             local_finish = time.time()
             timings['local_save'] = local_finish - start_time
-            log.info(f'Saving {filename} to S3 bucket ffa-dev')
+            log.info(f'Saving {filename} to S3 bucket {settings.S3_DESTINATION}')
             s3 = boto3.client('s3')
             with open(f'{destination}{filename}', 'rb') as data:
                 # apparently this overwrites existing files.
                 # something to think about?
-                s3.upload_fileobj(data, 'ffa-dev', filename)
+                s3.upload_fileobj(data, settings.S3_DESTINATION, filename)
             timings['s3_save'] = time.time() - local_finish
             os.remove(f'{destination}{filename}')
         log.info(timings)

--- a/api/v1/endpoints/listings.py
+++ b/api/v1/endpoints/listings.py
@@ -41,7 +41,7 @@ class Listings(Resource):
 class Listing(Resource):
     @api.expect(listing_arguments)
     @api.marshal_with(new_listing)
-    @api.response(201, constants.NEW_LISTING_SUCCESS)
+    @api.response(201, constants.NEW_CANDIDATE_SUCCESS)
     @api.response(400, constants.MISSING_PAYLOAD_DATA)
     @api.response(500, constants.SERVER_ERROR)
     def post(self):

--- a/protocol/__init__.py
+++ b/protocol/__init__.py
@@ -21,6 +21,7 @@ class Protocol():
     """
     def __init__(self):
         self.datatrust = None
+        self.voting = None
 
     def init_protocol(self, rpc_path, datatrust_contract, datatrust_host, voting_contract, datatrust_key, datatrust_wallet):
         """
@@ -53,6 +54,8 @@ class Protocol():
         log.info('Getting current datatrust address from network')
         self.datatrust = Datatrust(self.datatrust_wallet)
         self.datatrust.at(self.w3, self.datatrust_contract)
+        self.voting = Voting(self.datatrust_wallet)
+        self.voting.at(self.w3, self.voting_contract)
 
         backend = call(self.datatrust.get_backend_address())
         datatrust_hash = self.w3.sha3(text=self.datatrust_host)

--- a/protocol/__init__.py
+++ b/protocol/__init__.py
@@ -122,7 +122,6 @@ class Protocol():
         Register a host as the datatrust in protocol
         """
         log.info('****Registering host****')
-        tx_count = self.w3.eth.getTransactionCount(self.datatrust_wallet) + 1
         register = send(self.w3, self.datatrust_key, self.datatrust.register(self.datatrust_host))
         self.wait_for_mining(register)
         voting = Voting(self.datatrust_wallet)

--- a/tests/test_appserver.py
+++ b/tests/test_appserver.py
@@ -20,21 +20,24 @@ def test_health(client):
 def test_get_listings_success(client):
     get_listings = client.get('/api/v1/listings/')
     listings = json.loads(get_listings.data)
-    assert listings['items'] is None
+    assert get_listings.status_code == 200
 
 def test_listings_post_success(client):
-    post_listing = client.post('/api/v1/listings/foo', data=dict(
+    post_listing = client.post('/api/v1/listings/', data=dict(
+        listing_hash='foo',
         title='asdf',
         description='asdf',
         license='asdf',
         file_type='asdf',
         md5_sum='asdf'
     ))
-    assert post_listing.status_code == 200
-    assert b'You uploaded a file' in post_listing.data
+    assert post_listing.status_code == 201
+    res = json.loads(post_listing.data.decode('UTF-8'))
+    assert constants.NEW_CANDIDATE_SUCCESS == res['message']
 
 def test_listings_post_missing_title(client):
-    post_listing = client.post('/api/v1/listings/foo', data=dict(
+    post_listing = client.post('/api/v1/listings/', data=dict(
+        listing_hash='asdf',
         description='asdf',
         license='asdf',
         file_type='asdf',
@@ -45,7 +48,8 @@ def test_listings_post_missing_title(client):
     assert response['message'] == (constants.MISSING_PAYLOAD_DATA % 'title')
 
 def test_listings_post_missing_description(client):
-    post_listing = client.post('/api/v1/listings/foo', data=dict(
+    post_listing = client.post('/api/v1/listings/', data=dict(
+        listing_hash='foo',
         title='asdf',
         license='asdf',
         file_type='asdf',
@@ -56,7 +60,8 @@ def test_listings_post_missing_description(client):
     assert response['message'] == (constants.MISSING_PAYLOAD_DATA % 'description')
 
 def test_listings_post_missing_license(client):
-    post_listing = client.post('/api/v1/listings/foo', data=dict(
+    post_listing = client.post('/api/v1/listings/', data=dict(
+        listing_hash='foo',
         title='asdf',
         description='asdf',
         file_type='asdf',
@@ -67,7 +72,8 @@ def test_listings_post_missing_license(client):
     assert response['message'] == (constants.MISSING_PAYLOAD_DATA % 'license')
 
 def test_listings_post_missing_file_type(client):
-    post_listing = client.post('/api/v1/listings/foo', data=dict(
+    post_listing = client.post('/api/v1/listings/', data=dict(
+        listing_hash='foo',
         title='asdf',
         description='asdf',
         license='asdf',
@@ -78,7 +84,8 @@ def test_listings_post_missing_file_type(client):
     assert response['message'] == (constants.MISSING_PAYLOAD_DATA % 'file_type')
 
 def test_listings_post_missing_md5_sum(client):
-    post_listing = client.post('/api/v1/listings/foo', data=dict(
+    post_listing = client.post('/api/v1/listings/', data=dict(
+        listing_hash='foo',
         title='asdf',
         description='asdf',
         license='asdf',


### PR DESCRIPTION
This PR has a couple of additions to resolve issues identified on deployment:
1. I forgot to add the voting contract. D'oh!
2. If a prior candidate was registered to be the datatrust, a new datatrust would resolve that registration and register itself. If the transaction to resolve the prior registration hadn't been mined (hint: it wouldn't be, it takes at least 15 seconds), the attempt to register would fail. New code was added to wait for the prior transaction to be mined before proceeding. This same wait was applied after registration before confirming the new datatrust is a candidate.
3. S3 destination bucket was hard-coded instead of using values from Secrets Manager
4. Fix tests to work with new root `/listings` endpoint change